### PR TITLE
Update DropTarget.pas to not store TCustomDropTarget.HWND in DFM

### DIFF
--- a/Source/DropTarget.pas
+++ b/Source/DropTarget.pas
@@ -215,7 +215,7 @@ type
     property ShowImage: boolean read FShowImage write SetShowImage default True;
     // Target
     property Target: TWinControl read GetTarget write SetTarget;
-    property WinTarget: HWND read GetWinTarget write SetWinTarget;
+    property WinTarget: HWND read GetWinTarget write SetWinTarget stored False;
     property MultiTarget: boolean read FMultiTarget write FMultiTarget default False;
     property AutoRegister: boolean read FAutoRegister write FAutoRegister default True;
     // Auto-scroll


### PR DESCRIPTION
Maybe I don't know how to use the property WinTarget, and so I can't see why it should be stored in the DFM
So I added "stored False" so it does not get streamed